### PR TITLE
Adding notebooks to docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -33,7 +33,8 @@ release = '0.3.0'
 extensions = [
     "sphinx.ext.autodoc",
     'sphinx.ext.napoleon',
-    'm2r2'
+    'm2r2',
+    'nbsphinx',
 ]
 
 napoleon_google_docstring = False

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,10 +25,15 @@ Usage
 
 .. toctree::
    :maxdepth: 1
-   :hidden:
    :caption: User Guide
 
    API <source/pycomlink>
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Examples
+
+   notebooks/Basic CML processing workflow
 
 .. toctree::
   :maxdepth: 1


### PR DESCRIPTION
According to the documentation of readthedosc [here](https://docs.readthedocs.io/en/stable/guides/jupyter.html) it should be super easy to add the rendered notebooks in our docs. This PR does just that.